### PR TITLE
Validating and updating Order ID

### DIFF
--- a/Controller/Standard/Request.php
+++ b/Controller/Standard/Request.php
@@ -124,7 +124,7 @@ class Request extends \Cashfree\Cfcheckout\Controller\CfAbstract
     public function execute()
     {
         $order = $this->checkoutSession->getLastRealOrder();
-        $cashfreeOrderId = $order->getIncrementId();
+        $cashfreeOrderId = preg_replace("/[^a-zA-Z0-9_-]/", $this->config->getConfigData('order_id_replacement_char') ?? '-', $order->getIncrementId());
         $new_order_status = $this->config->getNewOrderStatus();
 
         $mage_version = $this->_objectManager->get('Magento\Framework\App\ProductMetadataInterface')->getVersion();

--- a/Model/OrderIdChar.php
+++ b/Model/OrderIdChar.php
@@ -1,0 +1,22 @@
+<?php
+namespace Cashfree\Cfcheckout\Model;
+
+class OrderIdChar implements \Magento\Framework\Option\ArrayInterface
+{
+    const CHAR_UNDERSCORE = '_';
+    const CHAR_HYPEN = '-';
+
+    public function toOptionArray()
+    {
+        return [
+            [
+                'value' => self::CHAR_HYPEN,
+                'label' => 'Hypen (-)',
+            ],[
+                'value' => self::CHAR_UNDERSCORE,
+                'label' => 'Underscore (_)'
+            ]
+        ];
+    }
+
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -53,6 +53,11 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/cashfree/enable_invoice</config_path>
                 </field>
+                <field id="order_id_replacement_char" translate="label" type="select" sortOrder="65" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>Order ID Replacement Character</label>
+                    <source_model>Cashfree\Cfcheckout\Model\OrderIdChar</source_model>
+                    <config_path>payment/cashfree/order_id_replacement_char</config_path>
+                </field>
                 <field id="sort_order" translate="label" type="text" sortOrder="71" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Sort Order</label>
                     <config_path>payment/cashfree/sort_order</config_path>


### PR DESCRIPTION
Currently Order ID allows only 2 non alphanumeric characters which are Underscore (_) and Hyphen (-).
So in order that Plugin works well irrespective of Order ID customization on User part, 

1. Config value is being introduced in Admin portal on Cashfree Plugin to select allowable character to replace any invalid character in Order ID.
2. Update Order ID according to user selection when sending API request to create order.